### PR TITLE
Initial 'Descobrir' page setup

### DIFF
--- a/src/components/CardMyProject/styles.ts
+++ b/src/components/CardMyProject/styles.ts
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 export const CardMyProjectContainer = styled.div`
   max-width: 24.3125rem;
   height: 16.125rem;
+  margin-bottom: 3.5rem;
 
   @media (min-width: 978px) {
     width: 24.3125rem;

--- a/src/pages/Feed/index.tsx
+++ b/src/pages/Feed/index.tsx
@@ -1,11 +1,33 @@
 import { Helmet } from 'react-helmet-async'
-import { FeedContainer } from './styles'
+
+import { CardMyProject } from '../../components/CardMyProject'
+import { SearchTags } from '../../components/SearchTags'
+import {
+  FeedContainer,
+  InputContainer,
+  ProjectsContainer,
+  SloganContainer,
+} from './styles'
 
 export function Feed() {
   return (
     <FeedContainer>
       <Helmet title="Descobrir" />
-      <h1>Descobrir</h1>
+      <SloganContainer>
+        <h1>
+          Junte-se à comunidade de inovação, inspiração e descobertas,
+          transformando experiências em conexões inesquecíveis
+        </h1>
+      </SloganContainer>
+      <InputContainer>
+        <SearchTags />
+      </InputContainer>
+      <ProjectsContainer>
+        <CardMyProject />
+        <CardMyProject />
+        <CardMyProject />
+        <CardMyProject />
+      </ProjectsContainer>
     </FeedContainer>
   )
 }

--- a/src/pages/Feed/styles.ts
+++ b/src/pages/Feed/styles.ts
@@ -1,5 +1,64 @@
 import styled from 'styled-components'
 
 export const FeedContainer = styled.div`
+  width: 100%;
   max-width: 80rem;
+  display: flex;
+  flex-direction: column;
+`
+
+export const SloganContainer = styled.div`
+  margin: 2.5rem auto auto;
+
+  h1 {
+    text-align: center;
+    font-weight: 500;
+    font-size: 1.5rem;
+  }
+
+  @media (min-width: 978px) {
+    width: 100%;
+    max-width: 700px;
+    margin: 6rem auto auto;
+
+    h1 {
+      font-size: 2rem;
+    }
+  }
+`
+
+export const InputContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 2.5rem;
+
+  @media (min-width: 978px) and (max-width: 1276px) {
+    margin: 0 auto;
+  }
+
+  @media (min-width: 978px) {
+    margin-top: 6rem;
+    max-width: 40rem;
+  }
+`
+
+export const ProjectsContainer = styled.div`
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: start;
+  gap: 1.5rem;
+
+  @media (min-width: 978px) {
+    flex-direction: row;
+    flex-wrap: wrap;
+    margin-top: 2.5rem;
+    gap: 1.5rem;
+  }
+
+  @media (min-width: 978px) and (max-width: 1276px) {
+    justify-content: center;
+  }
 `


### PR DESCRIPTION
The basis was made on the 'Discover' page, a route needs to be created in the back-end where it takes all projects, regardless of id or tag, the model card is ready and working.

![image](https://github.com/MatheusSanchez/orange-front/assets/43791636/a2d15a15-0204-4417-94ce-118492455020)
![image](https://github.com/MatheusSanchez/orange-front/assets/43791636/13357aa5-da88-48c6-88a0-1caa161f4a8b)

