### PR TITLE
Make image required and image upload integration

### DIFF
--- a/src/components/CardMyProject/index.tsx
+++ b/src/components/CardMyProject/index.tsx
@@ -1,6 +1,6 @@
 import Chip from '@mui/material/Chip'
 
-import projectPlaceholder from '../../assets/projectPlaceholder.jpg'
+// import projectPlaceholder from '../../assets/projectPlaceholder.jpg'
 import { OptionsButton } from './OptionsButton'
 import {
   AvatarContainer,
@@ -18,13 +18,18 @@ interface CardMyProjectProps {
   userName?: string
   date?: string
   tags?: string[]
+  photo_url?: string
 }
 
 export function CardMyProject(props: CardMyProjectProps) {
   return (
     <CardMyProjectContainer>
       <CardMyProjectContent>
-        <img src={projectPlaceholder} alt="" />
+        <div
+          className="image-container"
+          style={{ backgroundImage: `url(${props.photo_url})` }}
+        />
+
         <OptionContainer>
           <OptionsButton />
         </OptionContainer>

--- a/src/components/CardMyProject/styles.ts
+++ b/src/components/CardMyProject/styles.ts
@@ -2,6 +2,7 @@ import Avatar from '@mui/material/Avatar'
 import styled from 'styled-components'
 
 export const CardMyProjectContainer = styled.div`
+  width: 80vw;
   max-width: 24.3125rem;
   height: 16.125rem;
   margin-bottom: 3.5rem;
@@ -12,17 +13,19 @@ export const CardMyProjectContainer = styled.div`
 `
 
 export const CardMyProjectContent = styled.div`
-  max-width: 24.3125rem;
+  width: 100%;
   height: 16.125rem;
   background: ${(props) => props.theme['color-neutral-70']};
   border-radius: 4px;
   cursor: pointer;
   position: relative;
+  overflow: hidden;
 
-  img {
+  .image-container {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    background-size: cover;
+    background-position: center;
     border-radius: 4px;
   }
 

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 export const HeaderContainer = styled.header`
   width: 100%;
   background: #113;
-  min-width: 370px;
+  min-width: 320px;
 `
 
 export const HeaderContent = styled.div`

--- a/src/components/OpenModalCreateNewProject/ModalCreateNewProject/index.tsx
+++ b/src/components/OpenModalCreateNewProject/ModalCreateNewProject/index.tsx
@@ -46,6 +46,11 @@ const newProjectFormSchema = z.object({
     }),
   link: z.string(),
   description: z.string(),
+  imgFile: z
+    .unknown()
+    .refine((imgFile) => imgFile !== null && imgFile !== undefined, {
+      message: 'Imagem é obrigatória',
+    }),
 })
 
 type NewProjectFormSchema = z.infer<typeof newProjectFormSchema>
@@ -83,9 +88,10 @@ export function ModalCreateNewProject(props: ModalCreateNewProjectProps) {
   function handleChangeImgPreview(event: React.ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0]
     if (file) {
+      setImgFile(file)
+
       const imagePreview = URL.createObjectURL(file)
       props.setPreview(imagePreview)
-      setImgFile(file)
       setImageBanner(imagePreview)
     }
   }
@@ -106,12 +112,12 @@ export function ModalCreateNewProject(props: ModalCreateNewProjectProps) {
       if (imgFile) {
         const fileUploadForm = new FormData()
         fileUploadForm.append('avatar', imgFile)
-        await api.post(
-          `/project/${res.data.project.project.id}/photo`,
-          fileUploadForm,
-        )
+        await api
+          .post(`/project/${res.data.project.id}/photo`, fileUploadForm)
+          .then(() => {
+            openCreateModal()
+          })
       }
-      createModal()
     } catch (error) {
       openErrorModal()
     } finally {
@@ -123,7 +129,6 @@ export function ModalCreateNewProject(props: ModalCreateNewProjectProps) {
 
   function handleOpenModal() {
     setOpenModal(true)
-    // setImgPortfolio(file)
   }
 
   return (
@@ -233,6 +238,9 @@ export function ModalCreateNewProject(props: ModalCreateNewProjectProps) {
                   </LabelContent>
                 </label>
               </UploadFileInput>
+              {errors.imgFile && (
+                <ErrorMessage>{errors.imgFile.message}</ErrorMessage>
+              )}
             </UploadFileContent>
           </MainContainer>
           <a style={{ cursor: 'pointer' }} onClick={handleOpenModal}>

--- a/src/interfaces/ProjectProps.ts
+++ b/src/interfaces/ProjectProps.ts
@@ -7,4 +7,5 @@ export interface ProjectProps {
   created_at: string
   updated_at: string
   user_id: string
+  photo_url: string
 }

--- a/src/pages/MyProjects/index.tsx
+++ b/src/pages/MyProjects/index.tsx
@@ -114,6 +114,7 @@ export function MyProjects() {
                       userName={userData?.user.name}
                       date={format(new Date(project.created_at), 'dd/MM')}
                       tags={project.tags}
+                      photo_url={project.photo_url}
                     />
                   ))
                 : null}


### PR DESCRIPTION
In the form for creating a new project it is now mandatory to upload an image and displays an error message if the user tries to create the project without an image, I also adjusted the dimensions of small things in the project and integrated image upload to S3 on the front end.

![image](https://github.com/MatheusSanchez/orange-front/assets/43791636/14eda182-fbc1-48ef-aae8-87f3b211ae8a)
![image](https://github.com/MatheusSanchez/orange-front/assets/43791636/d54016f9-0db0-432c-812f-404da89cf797)
