### PR TITLE
Integrate delete project route and fix sytles

### DIFF
--- a/src/components/CardMyProject/OptionsButton/index.tsx
+++ b/src/components/CardMyProject/OptionsButton/index.tsx
@@ -5,14 +5,26 @@ import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import { useState } from 'react'
 
-export function OptionsButton() {
+import { useModalContext } from '../../../contexts/ModalContext'
+
+interface OptionsButtonProps {
+  project_id: string | undefined
+}
+
+export function OptionsButton(props: OptionsButtonProps) {
+  const { openAlertModal } = useModalContext()
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const open = Boolean(anchorEl)
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget)
   }
+
   const handleClose = () => {
     setAnchorEl(null)
+  }
+
+  function wantToDelete() {
+    openAlertModal(props.project_id)
   }
 
   return (
@@ -67,7 +79,7 @@ export function OptionsButton() {
         <MenuItem sx={{ minWidth: 180 }} onClick={handleClose}>
           Editar
         </MenuItem>
-        <MenuItem sx={{ minWidth: 180 }} onClick={handleClose}>
+        <MenuItem sx={{ minWidth: 180 }} onClick={wantToDelete}>
           Excluir
         </MenuItem>
       </Menu>

--- a/src/components/CardMyProject/index.tsx
+++ b/src/components/CardMyProject/index.tsx
@@ -19,6 +19,8 @@ interface CardMyProjectProps {
   date?: string
   tags?: string[]
   photo_url?: string
+  project_id?: string | undefined
+  blockOptions?: boolean
 }
 
 export function CardMyProject(props: CardMyProjectProps) {
@@ -29,10 +31,11 @@ export function CardMyProject(props: CardMyProjectProps) {
           className="image-container"
           style={{ backgroundImage: `url(${props.photo_url})` }}
         />
-
-        <OptionContainer>
-          <OptionsButton />
-        </OptionContainer>
+        {props.blockOptions ?? (
+          <OptionContainer>
+            <OptionsButton project_id={props.project_id} />
+          </OptionContainer>
+        )}
       </CardMyProjectContent>
       <ProjectInfoContainer>
         <UserInfoContainer>

--- a/src/components/Modals/index.tsx
+++ b/src/components/Modals/index.tsx
@@ -1,8 +1,10 @@
 import Modal from '@mui/material/Modal'
+import { useNavigate } from 'react-router-dom'
 
 import errorSvg from '../../assets/error.svg'
 import sucessSvg from '../../assets/sucess.svg'
 import { useModalContext } from '../../contexts/ModalContext'
+import { api } from '../../lib/axios'
 import {
   AlertContainer,
   BoxContainer,
@@ -12,6 +14,13 @@ import {
 
 export function EditModalSucess() {
   const { editModalState, closeEditModal } = useModalContext()
+  const navigate = useNavigate()
+
+  const handleCloseModal = () => {
+    closeEditModal()
+    navigate(0)
+  }
+
   return (
     <Modal open={editModalState} onClose={closeEditModal}>
       <BoxContainer>
@@ -21,7 +30,7 @@ export function EditModalSucess() {
           buttoncolor="save"
           textcollor="save"
           variant="contained"
-          onClick={closeEditModal}
+          onClick={handleCloseModal}
         >
           Voltar para projetos
         </StyledButton>
@@ -32,6 +41,13 @@ export function EditModalSucess() {
 
 export function CreateModalSucess() {
   const { createModalState, closeCreateModal } = useModalContext()
+  const navigate = useNavigate()
+
+  const handleCloseModal = () => {
+    closeCreateModal()
+    navigate(0)
+  }
+
   return (
     <Modal open={createModalState} onClose={closeCreateModal}>
       <BoxContainer>
@@ -41,7 +57,7 @@ export function CreateModalSucess() {
           buttoncolor="save"
           textcollor="save"
           variant="contained"
-          onClick={closeCreateModal}
+          onClick={handleCloseModal}
         >
           Voltar para projetos
         </StyledButton>
@@ -52,6 +68,13 @@ export function CreateModalSucess() {
 
 export function DeleteModalSucess() {
   const { deleteModalState, closeDeleteModal } = useModalContext()
+  const navigate = useNavigate()
+
+  const handleCloseModal = () => {
+    closeDeleteModal()
+    navigate(0)
+  }
+
   return (
     <Modal open={deleteModalState} onClose={closeDeleteModal}>
       <BoxContainer>
@@ -61,7 +84,7 @@ export function DeleteModalSucess() {
           buttoncolor="save"
           textcollor="save"
           variant="contained"
-          onClick={closeDeleteModal}
+          onClick={handleCloseModal}
         >
           Voltar para projetos
         </StyledButton>
@@ -133,6 +156,7 @@ export function AlertError() {
 
 export function ErrorModal() {
   const { errorModalState, closeErrorModal } = useModalContext()
+
   return (
     <Modal open={errorModalState} onClose={closeErrorModal}>
       <BoxContainer>
@@ -150,14 +174,28 @@ export function ErrorModal() {
     </Modal>
   )
 }
-
 export function AlertModal() {
-  const { alertModalState, closeAlertModal, openDeleteModal } =
-    useModalContext()
+  const {
+    alertModalState,
+    closeAlertModal,
+    openDeleteModal,
+    projectIdToBeDeleted,
+  } = useModalContext()
 
-  const handleDeleteProjectModal = () => {
+  const handleOpenDelete = () => {
     closeAlertModal()
-    openDeleteModal()
+    deleteProject()
+  }
+
+  async function deleteProject() {
+    try {
+      await api.delete(`/project/${projectIdToBeDeleted}`).then(() => {
+        openDeleteModal()
+      })
+    } catch (error) {
+      console.error('Erro ao processar a requisição', error)
+      throw error
+    }
   }
 
   return (
@@ -170,7 +208,7 @@ export function AlertModal() {
             variant="contained"
             buttoncolor="save"
             textcollor="save"
-            onClick={handleDeleteProjectModal}
+            onClick={handleOpenDelete}
           >
             Excluir
           </StyledButton>

--- a/src/components/OpenModalCreateNewProject/ModalCreateNewProject/index.tsx
+++ b/src/components/OpenModalCreateNewProject/ModalCreateNewProject/index.tsx
@@ -46,11 +46,6 @@ const newProjectFormSchema = z.object({
     }),
   link: z.string(),
   description: z.string(),
-  imgFile: z
-    .unknown()
-    .refine((imgFile) => imgFile !== null && imgFile !== undefined, {
-      message: 'Imagem é obrigatória',
-    }),
 })
 
 type NewProjectFormSchema = z.infer<typeof newProjectFormSchema>
@@ -62,6 +57,7 @@ export function ModalCreateNewProject(props: ModalCreateNewProjectProps) {
   const [imgFile, setImgFile] = useState<File | null>(null)
   const [openModal, setOpenModal] = useState(false)
   const [imageBanner, setImageBanner] = useState('')
+  const [errorMessage, setErrorMessage] = useState('')
   const [projectInfo, setProjectInfo] = useState({
     title: '',
     tags: '',
@@ -97,6 +93,11 @@ export function ModalCreateNewProject(props: ModalCreateNewProjectProps) {
   }
 
   async function handleCreateNewProject(data: NewProjectFormSchema) {
+    if (imgFile === null) {
+      setErrorMessage('A imagem é obrigatória')
+      return
+    }
+
     setLoadingAuth(true)
     try {
       await newProjectFormSchema.parseAsync(data)
@@ -238,9 +239,7 @@ export function ModalCreateNewProject(props: ModalCreateNewProjectProps) {
                   </LabelContent>
                 </label>
               </UploadFileInput>
-              {errors.imgFile && (
-                <ErrorMessage>{errors.imgFile.message}</ErrorMessage>
-              )}
+              {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
             </UploadFileContent>
           </MainContainer>
           <a style={{ cursor: 'pointer' }} onClick={handleOpenModal}>

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -10,6 +10,7 @@ interface ModalContextType {
   alertErrorModalState: boolean
   errorModalState: boolean
   alertModalState: boolean
+  projectIdToBeDeleted: string | undefined
   openEditModal: () => void
   openCreateModal: () => void
   openDeleteModal: () => void
@@ -17,7 +18,7 @@ interface ModalContextType {
   openChangePasswordModal: () => void
   openAlertErrorModal: () => void
   openErrorModal: () => void
-  openAlertModal: () => void
+  openAlertModal: (projectId: string | undefined) => void
   closeEditModal: () => void
   closeCreateModal: () => void
   closeDeleteModal: () => void
@@ -65,7 +66,13 @@ export function ModalProvider({ children }: ModalProviderProps) {
   const closeErrorModal = () => setErrorModalState(false)
 
   const [alertModalState, setAlertModalState] = useState(false)
-  const openAlertModal = () => setAlertModalState(true)
+  const [projectIdToBeDeleted, setProjectIdToBeDeleted] = useState<
+    string | undefined
+  >('')
+  function openAlertModal(projectId: string | undefined) {
+    setAlertModalState(true)
+    setProjectIdToBeDeleted(projectId)
+  }
   const closeAlertModal = () => setAlertModalState(false)
 
   return (
@@ -95,6 +102,7 @@ export function ModalProvider({ children }: ModalProviderProps) {
         alertModalState,
         openAlertModal,
         closeAlertModal,
+        projectIdToBeDeleted,
       }}
     >
       {children}

--- a/src/pages/Feed/index.tsx
+++ b/src/pages/Feed/index.tsx
@@ -39,8 +39,6 @@ export function Feed() {
     }
   }
 
-  console.log(projectsData)
-
   useEffect(() => {
     buscarProjetosPorTags()
   }, [chipData])
@@ -65,6 +63,8 @@ export function Feed() {
               userName={project.user_id}
               date={format(new Date(project.created_at), 'dd/MM')}
               tags={project.tags}
+              project_id={project.id}
+              blockOptions
             />
           ))
         ) : (

--- a/src/pages/MyProjects/index.tsx
+++ b/src/pages/MyProjects/index.tsx
@@ -65,8 +65,6 @@ export function MyProjects() {
     }
   }
 
-  console.log(chipData)
-
   useEffect(() => {
     if (userData?.user.id) {
       getUserProjects()
@@ -99,28 +97,28 @@ export function MyProjects() {
             </LoaderContainer>
           ) : (
             <>
-              {userProjectsData.length === 0 && chipData.length === 0 && (
+              {userProjectsData.length === 0 && chipData.length === 0 ? (
                 <>
                   <UploadFileContent onClick={handleOpenModal} />
                   <EmptyFileContent />
                   <EmptyFileContent />
                 </>
-              )}
-
-              {userProjectsData.length > 0 && chipData.length === 0
-                ? userProjectsData.map((project) => (
+              ) : (
+                <>
+                  {userProjectsData.map((project) => (
                     <CardMyProject
                       key={project.id}
                       userName={userData?.user.name}
                       date={format(new Date(project.created_at), 'dd/MM')}
                       tags={project.tags}
                       photo_url={project.photo_url}
+                      project_id={project.id}
                     />
-                  ))
-                : null}
-
-              {userProjectsData.length === 0 && chipData.length >= 1 && (
-                <EmptySearch>Nenhum projeto encontrado</EmptySearch>
+                  ))}
+                  {chipData.length >= 1 && userProjectsData.length === 0 && (
+                    <EmptySearch>Nenhum projeto encontrado</EmptySearch>
+                  )}
+                </>
               )}
             </>
           )}


### PR DESCRIPTION
The image of the create new project modal is now definitely mandatory and showing a message, the routes for deleting projects are working and some corrections to the styles have been made.

![image](https://github.com/MatheusSanchez/orange-front/assets/43791636/92fd858a-77a2-4277-8c45-31f27b71b3d0)
