### PR TITLE
fix route download

### DIFF
--- a/src/components/OpenModalViewProject/ModalViewProject/index.tsx
+++ b/src/components/OpenModalViewProject/ModalViewProject/index.tsx
@@ -115,9 +115,9 @@ export function ModalViewProject(props: ModalViewProjectProps) {
         )}
         <p>{description}</p>
         <h4>Download</h4>
-        <Link to={link} target="_blank">
+        <a href={`http://${link}`} target="_blank" rel="noopener noreferrer">
           {link}
-        </Link>
+        </a>
       </ModalBox>
     </Modal>
   )


### PR DESCRIPTION
![download-route](https://github.com/MatheusSanchez/orange-front/assets/84147924/df453ea8-8e0e-44f6-9f7d-c84187ee09b5)
fix new guide after click at download link